### PR TITLE
Match Program and immediately traverse to transform before following plugins using the same technique

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -43,8 +43,8 @@ const traverseExpression = (t, arg) => {
   return null;
 };
 
-export default ({'types': t}) => ({
-  'visitor': {
+export default ({ 'types': t }) => {
+  const visitor = {
     CallExpression(path, state) {
       if (path.node.callee.name !== 'require') {
         return;
@@ -74,5 +74,12 @@ export default ({'types': t}) => ({
         path.node.source.value = replacePrefix(path.node.source.value, state.opts, state.file.opts.filename);
       }
     }
-  }
-});
+  };
+  return {
+    'visitor': {
+      Program(path, state) {
+        path.traverse(visitor, state);
+      }
+    }
+  };
+};


### PR DESCRIPTION
I'm using this plugin in a Meteor project so I can run external tools and replicate Meteor's own build system's root import. Meteor has moved to using [Reify](https://www.npmjs.com/package/reify) for imports. Their [babel plugin](https://www.npmjs.com/package/babel-plugin-transform-es2015-modules-reify) appears to run ahead of this plugin no matter the order in `.babelrc`. 

The reason and answer is that babel plugins can run immediately by matching `Program` and traversing the AST themselves. This PR adds that functionality to this plugin.

### Compatibility considerations

As this plugin simply changes the import source location to a relative one I don't anticipate that it running now sooner in existing users' setups would cause any problems. 

### Tests

I haven't added any tests. All the existing tests and linting passes. I'm not sure how to test that it traverses immediately from `Program`. 