### PR TITLE
Ignore root path prefix not followed by forward slash

### DIFF
--- a/plugin/helper.js
+++ b/plugin/helper.js
@@ -7,10 +7,6 @@ export const hasRootPathPrefixInString = (importPath, rootPathPrefix = '~') => {
   let containsRootPathPrefix = false;
 
   if (typeof importPath === 'string') {
-    if (importPath.substring(0, 1) === rootPathPrefix) {
-      containsRootPathPrefix = true;
-    }
-
     const firstTwoCharactersOfString = importPath.substring(0, 2);
     if (firstTwoCharactersOfString === `${rootPathPrefix}/`) {
       containsRootPathPrefix = true;

--- a/test/helper.spec.js
+++ b/test/helper.spec.js
@@ -14,6 +14,11 @@ describe('helper#transformRelativeToRootPath', () => {
     expect(result).to.equal(rootPath);
   });
 
+  it('ignores path prefix not followed by forward slash', () => {
+      const result = transformRelativeToRootPath('~util', '../shared', '~', 'test.js');
+      expect(result).to.equal('~util');
+  });
+
   it('considers .. in relative path', () => {
     const result = transformRelativeToRootPath('~/util', '../shared', '~', 'test.js');
     expect(result).to.not.equal(`${path.resolve('../shared')}/util/test.js`);
@@ -40,6 +45,10 @@ describe('helper#hasRootPathPrefixInString', () => {
   it('returns a boolean', () => {
     const func = hasRootPathPrefixInString();
     expect(func).to.be.a('boolean');
+  });
+
+  it('ignores path prefix not followed by forward slash', () => {
+    expect( hasRootPathPrefixInString('~some/path') ).to.be.false;
   });
 
   it('check if "~/" is at the beginning of the string', () => {


### PR DESCRIPTION
Currently, the plugin "matches" the root path prefix even if it's not followed by a forward slash, so something like `import "~module"` can end up being expanded as `import "../componentsmodule"` (note the missing slash), even though technically in this case "~" is a part of the module's name (rather than a path component).

In addition to being technically "incorrect", current behavior also interferes with npm's [scoped packages](https://docs.npmjs.com/misc/scope) syntax when the root path prefix is set to "@" (a relatively popular preference):

```
// the following breaks when babel-plugin-root-import is enabled
import module from "@acme/module" 
```

Again, in this case "@" is a part of the module name and should not be treated as a root path prefix. 

The PR addresses this issue while keeping the `"~/module"` and `"@/acme/module"` behavior as is.

