### PR TITLE
Add note on reverting to using relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ module.name_mapper='^{rootPathPrefix}/\(.*\)$' -> '<PROJECT_ROOT>{rootPathSuffix
 Webpack delivers a similar feature, if you just want to prevent end-less import strings you can also define `aliases` in the `resolve` module, at the moment it doesn't support custom/different symbols and multiple/custom suffixes.
 [READ MORE](http://xabikos.com/2015/10/03/Webpack-aliases-and-relative-paths/)
 
+### Want to revert back to relative paths?
+Sometimes tooling might not be up to scratch, meaning you lose features such as navigation in your IDE. In such cases you might want to revert back to using relative paths again. If you have a significant amount of files, it might be worth looking into [tooling](https://www.npmjs.com/package/convert-root-import) to help you with the conversion.
+
 ## Change Log
 #### 5.0.0 - 2017-02-10
 - More consistent name: babel-plugin-root-import [#63](https://github.com/entwicklerstube/babel-plugin-root-import/issues/63)


### PR DESCRIPTION
This is a shameless plug, but thought it might be of use to users of your plugin that finds themselves in a position where they need to remove use of the plugin in hundreds of files. 

In our case, we found some big hindrances in our workflow, as WebStorm didn't understand the paths. This meant that the navigation feature, where Ctrl-Clicking a file would bring you directly to it, didn't work, and exports were marked as unused for the same reason (leading to false negatives when searching for usage in refactoring tools).

Also, the absolute paths meant using `proxyquire` and other link layer stubbing tools didn't work, as the paths in the tests no longer matched up.

I searched around for tools to help me do this, but found none, so made my very simple (no lexing, tokenizing, or AST building) [tool to help me do the conversion](https://github.com/fatso83/convert-root-import). It might be worth noting this in a paragraph somewhere.