### PR TITLE
fix issue with sourceFile on windows systems

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,3 +1,5 @@
+import slash from 'slash';
+
 import {hasRootPathPrefixInString, transformRelativeToRootPath} from './helper';
 
 const replacePrefix = (path, opts = [], sourceFile) => {
@@ -18,7 +20,7 @@ const replacePrefix = (path, opts = [], sourceFile) => {
     }
 
     if (hasRootPathPrefixInString(path, rootPathPrefix)) {
-      return transformRelativeToRootPath(path, rootPathSuffix, rootPathPrefix, sourceFile);
+      return transformRelativeToRootPath(path, rootPathSuffix, rootPathPrefix, slash(sourceFile));
     }
   }
 


### PR DESCRIPTION
Fix issue explained here : https://github.com/entwicklerstube/babel-plugin-root-import/issues/94

sourcefile on windows need to be transformed ('\\' -> '/') before being provided to transformRelativeToRootPath.

I used the slash module which was already a dependancy

Code review welcome of course