### PR TITLE
Added support for custom length prefixes

### DIFF
--- a/plugin/helper.js
+++ b/plugin/helper.js
@@ -7,12 +7,11 @@ export const hasRootPathPrefixInString = (importPath, rootPathPrefix = '~') => {
   let containsRootPathPrefix = false;
 
   if (typeof importPath === 'string') {
-    if (importPath.substring(0, 1) === rootPathPrefix) {
+    if (importPath.startsWith(rootPathPrefix)) {
       containsRootPathPrefix = true;
     }
 
-    const firstTwoCharactersOfString = importPath.substring(0, 2);
-    if (firstTwoCharactersOfString === `${rootPathPrefix}/`) {
+    if (importPath.startsWith(`${rootPathPrefix}/`)) {
       containsRootPathPrefix = true;
     }
   }
@@ -23,10 +22,9 @@ export const hasRootPathPrefixInString = (importPath, rootPathPrefix = '~') => {
 export const transformRelativeToRootPath = (importPath, rootPathSuffix, rootPathPrefix, sourceFile = '') => {
   let withoutRootPathPrefix = '';
   if (hasRootPathPrefixInString(importPath, rootPathPrefix)) {
-    if (importPath.substring(0, 1) === '/') {
-      withoutRootPathPrefix = importPath.substring(1, importPath.length);
-    } else {
-      withoutRootPathPrefix = importPath.substring(2, importPath.length);
+    withoutRootPathPrefix = importPath.slice(rootPathPrefix.length)
+    if (withoutRootPathPrefix.substring(0, 1) === '/') {
+      withoutRootPathPrefix = withoutRootPathPrefix.slice(1)
     }
 
     const absolutePath = path.resolve(`${rootPathSuffix ? rootPathSuffix : './'}/${withoutRootPathPrefix}`);

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -154,6 +154,69 @@ describe('Babel Root Import - Plugin', () => {
     expect(transformedRequire.code).to.contain(targetRequire);
   });
 
+  it('uses a custom string as a prefix to detect a root-import path', () => {
+    const targetRequire = slash(`/some/example.js`);
+    const transformedImport = babel.transform("import SomeExample from 'src/some/example.js';", {
+      plugins: [[
+        BabelRootImportPlugin, {
+          rootPathPrefix: 'src'
+        }
+      ]]
+    });
+    const transformedRequire = babel.transform("var SomeExample = require('src/some/example.js');", {
+      plugins: [[
+        BabelRootImportPlugin, {
+          rootPathPrefix: 'src'
+        }
+      ]]
+    });
+
+    expect(transformedImport.code).to.contain(targetRequire);
+    expect(transformedRequire.code).to.contain(targetRequire);
+  });
+
+  it('uses a custom string with multiple parts as a prefix to detect a root-import path', () => {
+	const targetRequire = slash(`/some/example.js`);
+	const transformedImport = babel.transform("import SomeExample from 'src/js/some/example.js';", {
+	  plugins: [[
+		BabelRootImportPlugin, {
+		  rootPathPrefix: 'src/js'
+		}
+	  ]]
+	});
+	const transformedRequire = babel.transform("var SomeExample = require('src/js/some/example.js');", {
+	  plugins: [[
+		BabelRootImportPlugin, {
+		  rootPathPrefix: 'src/js'
+		}
+	  ]]
+	});
+
+	expect(transformedImport.code).to.contain(targetRequire);
+	expect(transformedRequire.code).to.contain(targetRequire);
+  });
+
+  it('uses a custom string with trailing slash as a prefix to detect a root-import path', () => {
+	const targetRequire = slash(`/some/example.js`);
+	const transformedImport = babel.transform("import SomeExample from 'src/some/example.js';", {
+	  plugins: [[
+		BabelRootImportPlugin, {
+		  rootPathPrefix: 'src/'
+		}
+	  ]]
+	});
+	const transformedRequire = babel.transform("var SomeExample = require('src/some/example.js');", {
+	  plugins: [[
+		BabelRootImportPlugin, {
+		  rootPathPrefix: 'src/'
+		}
+	  ]]
+	});
+
+	expect(transformedImport.code).to.contain(targetRequire);
+	expect(transformedRequire.code).to.contain(targetRequire);
+  });
+
   it('uses "@" as custom prefix to detect a root-import path and has a custom rootPathSuffix', () => {
     const targetRequire = slash(`/some/example.js`);
     const transformedImport = babel.transform("import SomeExample from '@/example.js';", {


### PR DESCRIPTION
Using prefixes besides ~, @ or - can be an alternative to using NODE_PATH to specify where imports should be found.

If used like this `
{
  rootPathPrefix: 'src/',
  rootPathSuffix: 'src/
}
`
All imports to the src folder are made relative and using NODE_PATH is not necessary anymore.