### PR TITLE
Added support for nested projects

### DIFF
--- a/build/helper.js
+++ b/build/helper.js
@@ -1,0 +1,97 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.transformRelativeToRootPath = exports.hasRootPathPrefixInString = undefined;
+
+var _fs = require('fs');
+
+var _fs2 = _interopRequireDefault(_fs);
+
+var _slash = require('slash');
+
+var _slash2 = _interopRequireDefault(_slash);
+
+var _path = require('path');
+
+var _path2 = _interopRequireDefault(_path);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var processRoot = (0, _slash2.default)(global.rootPath || process.cwd());
+var roots = {};
+
+var hasRootPathPrefixInString = exports.hasRootPathPrefixInString = function hasRootPathPrefixInString(importPath) {
+  var rootPathPrefix = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '~';
+
+  var containsRootPathPrefix = false;
+
+  if (typeof importPath === 'string') {
+    if (importPath.substring(0, 1) === rootPathPrefix) {
+      containsRootPathPrefix = true;
+    }
+
+    var firstTwoCharactersOfString = importPath.substring(0, 2);
+    if (firstTwoCharactersOfString === rootPathPrefix + '/') {
+      containsRootPathPrefix = true;
+    }
+  }
+
+  return containsRootPathPrefix;
+};
+
+var transformRelativeToRootPath = exports.transformRelativeToRootPath = function transformRelativeToRootPath(importPath, rootPathSuffix, rootPathPrefix, sourceFile) {
+  var withoutRootPathPrefix = '';
+  if (hasRootPathPrefixInString(importPath, rootPathPrefix)) {
+    if (importPath.substring(0, 1) === '/') {
+      withoutRootPathPrefix = importPath.substring(1, importPath.length);
+    } else {
+      withoutRootPathPrefix = importPath.substring(2, importPath.length);
+    }
+
+    var sourceDir = _path2.default.dirname(sourceFile);
+    var root = findRoot(sourceDir);
+    var absolutePath = (0, _slash2.default)(_path2.default.resolve(root, rootPathSuffix || './', withoutRootPathPrefix));
+    var relativePath = (0, _slash2.default)(_path2.default.relative(sourceDir, absolutePath));
+
+    // if file is located in the same folder
+    if (relativePath.indexOf('../') !== 0) {
+      relativePath = './' + relativePath;
+    }
+
+    // if the entry has a slash, keep it
+    if (importPath[importPath.length - 1] === '/') {
+      relativePath += '/';
+    }
+
+    return relativePath;
+  }
+
+  if (typeof importPath === 'string') {
+    return importPath;
+  }
+
+  throw new Error('ERROR: No path passed');
+};
+
+function findRoot(dirname) {
+  // if the root is already cached, return it
+  var root = roots[dirname];
+  if (root) return root;
+
+  // search for the root
+  while (true) {
+    // if .babelrc exists here, then we found the root
+    var brcpath = _path2.default.resolve(dirname, '.babelrc');
+    if (_fs2.default.existsSync(brcpath)) {
+      roots[dirname] = dirname;
+      return dirname;
+    }
+
+    // move to the parent directory, if it exists
+    var nextdir = _path2.default.dirname(dirname);
+    if (nextdir === dirname) return processRoot;
+    dirname = nextdir;
+  }
+}

--- a/build/index.js
+++ b/build/index.js
@@ -1,0 +1,96 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _helper = require('./helper');
+
+var replacePrefix = function replacePrefix(path) {
+  var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : [];
+  var sourceFile = arguments[2];
+
+  var options = [].concat(opts);
+
+  for (var i = 0; i < options.length; i++) {
+    var rootPathSuffix = '';
+    var rootPathPrefix = '';
+    var option = options[i];
+
+    if (option.rootPathSuffix && typeof option.rootPathSuffix === 'string') {
+      rootPathSuffix = option.rootPathSuffix;
+    }
+    if (option.rootPathPrefix && typeof option.rootPathPrefix === 'string') {
+      rootPathPrefix = option.rootPathPrefix;
+    } else {
+      rootPathPrefix = '~';
+    }
+
+    if ((0, _helper.hasRootPathPrefixInString)(path, rootPathPrefix)) {
+      return (0, _helper.transformRelativeToRootPath)(path, rootPathSuffix, rootPathPrefix, sourceFile);
+    }
+  }
+
+  return path;
+};
+
+/**
+ * Recursively traverses binary  expressions to find the first `StringLiteral` if any.
+ * @param  {Object} t           Babel types
+ * @param  {Node} arg           a Babel node
+ * @return {StringLiteral?}
+ */
+var traverseExpression = function traverseExpression(t, arg) {
+  if (t.isStringLiteral(arg)) {
+    return arg;
+  }
+
+  if (t.isBinaryExpression(arg)) {
+    return traverseExpression(t, arg.left);
+  }
+
+  return null;
+};
+
+exports.default = function (_ref) {
+  var t = _ref.types;
+
+  var visitor = {
+    CallExpression: function CallExpression(path, state) {
+      if (path.node.callee.name !== 'require') {
+        return;
+      }
+
+      var args = path.node.arguments;
+      if (!args.length) {
+        return;
+      }
+
+      var firstArg = traverseExpression(t, args[0]);
+
+      if (firstArg) {
+        firstArg.value = replacePrefix(firstArg.value, state.opts, state.file.opts.filename);
+      }
+    },
+    ImportDeclaration: function ImportDeclaration(path, state) {
+      path.node.source.value = replacePrefix(path.node.source.value, state.opts, state.file.opts.filename);
+    },
+    ExportNamedDeclaration: function ExportNamedDeclaration(path, state) {
+      if (path.node.source) {
+        path.node.source.value = replacePrefix(path.node.source.value, state.opts, state.file.opts.filename);
+      }
+    },
+    ExportAllDeclaration: function ExportAllDeclaration(path, state) {
+      if (path.node.source) {
+        path.node.source.value = replacePrefix(path.node.source.value, state.opts, state.file.opts.filename);
+      }
+    }
+  };
+  return {
+    'visitor': {
+      Program: function Program(path, state) {
+        path.traverse(visitor, state);
+      }
+    }
+  };
+};

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -43,7 +43,7 @@ const traverseExpression = (t, arg) => {
   return null;
 };
 
-export default ({ 'types': t }) => {
+export default ({types: t}) => {
   const visitor = {
     CallExpression(path, state) {
       if (path.node.callee.name !== 'require') {


### PR DESCRIPTION
In the base fork, the rootPathSuffix values are always calculated relative to the current working directory of the babel process. When there is only one .babelrc file. and therefore only one set of path transformations, this works fine.

However, if there are multiple projects, each with its own .babelrc file, then it becomes difficult or impossible to reconcile path transformations from the current working directory. What we really want instead is to perform path transformations relative to the location of each project's .babelrc file. This fork changes the path transformation algorithm to do just that.

When a file is being transformed, the file's .babelrc file is located by traversing the directory chain. Once a .babelrc file is located, the directory of the .babelrc file is used as the root of the path transformation algorithm. This means that path transformations are always relative the .babelrc file, and nested projects will work correctly. The locations of the .babelrc files are cached for a performance improvement.

All of the existing mocha tests pass successfully. However, this may be a breaking change for projects that have a very unusual tool chain setup. Also, this change expects the babel configuration to be in a separate .babelrc file instead of inside the package.json file.