### PR TITLE
fix sourceFile issue on windows with chinese character in directory

### DIFF
--- a/plugin/helper.js
+++ b/plugin/helper.js
@@ -21,6 +21,7 @@ export const hasRootPathPrefixInString = (importPath, rootPathPrefix = '~') => {
 };
 
 export const transformRelativeToRootPath = (importPath, rootPathSuffix, rootPathPrefix, sourceFile = '') => {
+  sourceFile = sourceFile.replace(/\\/g, '/');
   let withoutRootPathPrefix = '';
   if (hasRootPathPrefixInString(importPath, rootPathPrefix)) {
     if (importPath.substring(0, 1) === '/') {


### PR DESCRIPTION
chinese character in directory

```
D:\\test\\目录\\todos\\todos.js
```

should be transform to

```
D:/test/目录/todos/todos.js
```