### PR TITLE
removed restriction for prefix.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,13 @@
   "version": "6.1.0",
   "description": "Babel Plugin to enable relative root-import",
   "author": "Michael J. Zoidl <github@michaelzoidl.com>",
+  "contributors": [
+    {
+      "name" : "Tomas Savigliano",
+      "email" : "ralusek@gmail.com",
+      "url" : "https://github.com/ralusek"
+    }
+  ],
   "license": "MIT",
   "main": "index.js",
   "files": [

--- a/plugin/helper.js
+++ b/plugin/helper.js
@@ -4,30 +4,19 @@ import path from 'path';
 const root = slash(global.rootPath || process.cwd());
 
 export const hasRootPathPrefixInString = (importPath, rootPathPrefix = '~') => {
-  let containsRootPathPrefix = false;
+  const re = new RegExp('^' + rootPathPrefix, 'g');
 
-  if (typeof importPath === 'string') {
-    if (importPath.substring(0, 1) === rootPathPrefix) {
-      containsRootPathPrefix = true;
-    }
-
-    const firstTwoCharactersOfString = importPath.substring(0, 2);
-    if (firstTwoCharactersOfString === `${rootPathPrefix}/`) {
-      containsRootPathPrefix = true;
-    }
-  }
-
-  return containsRootPathPrefix;
+  return !!(
+    (typeof importPath === 'string') &&
+    importPath.match(re)
+  );
 };
 
 export const transformRelativeToRootPath = (importPath, rootPathSuffix, rootPathPrefix, sourceFile = '') => {
-  let withoutRootPathPrefix = '';
+  const re = new RegExp('^' + rootPathPrefix, 'g');
+
   if (hasRootPathPrefixInString(importPath, rootPathPrefix)) {
-    if (importPath.substring(0, 1) === '/') {
-      withoutRootPathPrefix = importPath.substring(1, importPath.length);
-    } else {
-      withoutRootPathPrefix = importPath.substring(2, importPath.length);
-    }
+    const withoutRootPathPrefix = importPath.replace(re, '');
 
     const absolutePath = path.resolve(`${rootPathSuffix ? rootPathSuffix : './'}/${withoutRootPathPrefix}`);
     let sourcePath = sourceFile.substring(0, sourceFile.lastIndexOf('/'));


### PR DESCRIPTION
This simplifies some of the logic for detecting prefixes as well as removing the prefix from the path, removing the prefix restriction from being 1-2 characters to instead support any number of characters.

In order to detect a prefix, instead of checking if either the substring 0-1 or the substring 0-2 of the path provided are exact matches with the prefix, instead a regular expression for the prefix is used, with the `^` contingency added (indicating that the provided string must BEGIN with the prefix).

Likewise, when removing the prefix from the path, rather than removing either the first 1 or 2 characters, depending on the prefix length, instead we replace the incidence of the prefix with empty string.