### PR TITLE
Update slash to version 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prepublish": "npm run test && npm run compile"
   },
   "dependencies": {
-    "slash": "^1.0.0"
+    "slash": "^2.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.2",


### PR DESCRIPTION
The new version simply requires Node >= 6, and has no other major changes.