### PR TITLE
Update README example for multiple prefixes / suffixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,7 @@ You can supply an array of the above. The plugin will try each prefix/suffix pai
 ```javascript
 {
   "plugins": [
-    ["babel-plugin-root-import", {
-      "paths": [{
+    ["babel-plugin-root-import", [{
         // `~` is the default so you can remove this if you want
         "rootPathPrefix": "~",
         "rootPathSuffix": "src/js"
@@ -138,7 +137,7 @@ You can supply an array of the above. The plugin will try each prefix/suffix pai
         "rootPathPrefix": "#",
         "rootPathSuffix": "../../src/in/parent"
       }]
-    }]
+    ]
   ]
 }
 


### PR DESCRIPTION
I was struggling with using multiple custom prefixes / suffixes.

I saw this comment in an issue, which showed a .babelrc that looked a bit different from the README, and that seems to work correctly - https://github.com/entwicklerstube/babel-plugin-root-import/issues/74#issuecomment-301325742

I figured I'd update the README and ask whether this is the correct way to use multiple prefixes / suffixes in one swoop 😄