### PR TITLE
Fixes Windows unicode paths

### DIFF
--- a/plugin/helper.js
+++ b/plugin/helper.js
@@ -36,7 +36,7 @@ export const transformRelativeToRootPath = (
 
     sourcePath = path.resolve(sourcePath);
 
-    let relativePath = slash(path.relative(sourcePath, absolutePath));
+    let relativePath = path.relative(sourcePath, absolutePath).replace(/\\/g, '/');
 
     // if file is located in the same folder
     if (relativePath.indexOf('../') !== 0) {


### PR DESCRIPTION
The slash package avoids transforming paths with unicode characters in them, which is correct except for the final path where we want to have `/`s in the output require/import.

Resolves https://github.com/entwicklerstube/babel-plugin-root-import/pull/102