### PR TITLE
fix support for absolute root paths

### DIFF
--- a/plugin/helper.js
+++ b/plugin/helper.js
@@ -25,18 +25,7 @@ export const transformRelativeToRootPath = (
 
     let sourcePath = sourceFile.substring(0, sourceFile.lastIndexOf('/'));
 
-    // if the path is an absolute path (webpack sends '/Users/foo/bar/baz.js' here)
-    if (
-      sourcePath.indexOf('/') === 0 ||
-      sourcePath.indexOf(':/') === 1 ||
-      sourcePath.indexOf(':\\') === 1
-    ) {
-      sourcePath = sourcePath.substring(root.length + 1);
-    }
-
-    sourcePath = path.resolve(sourcePath);
-
-    let relativePath = path.relative(sourcePath, absolutePath).replace(/\\/g, '/');
+    let relativePath = path.relative(path.resolve(sourcePath), absolutePath).replace(/\\/g, '/');
 
     // if file is located in the same folder
     if (relativePath.indexOf('../') !== 0) {

--- a/test/helper.spec.js
+++ b/test/helper.spec.js
@@ -35,6 +35,25 @@ describe('helper#transformRelativeToRootPath', () => {
     expect(result).to.equal(rootPath);
   });
 
+  it('supports an absolute custom root path', () => {
+    const importPath = '~/another/path';
+    const root = '/root-directory';
+
+    // The file is 2 directories down the custom root.
+    const file = '/root-directory/some/path/file.js';
+    
+    const result = transformRelativeToRootPath(
+      importPath,
+      '',
+      '~/',
+      file,
+      root
+    );
+
+    expect(result).to.equal('../../another/path')
+  });
+
+
   it('supports custom root function', () => {
     const rootPath = slash('./internals/foo');
     const result = transformRelativeToRootPath(


### PR DESCRIPTION
This PR fixes support for having an absolute path as `root` in options.root.


We are using the custom root as a function in a mono repo setup. Our setup is something like this

````
apps
  - first-app
  - second-app
babel.config.js
````

Within these apps, we use this plugin to enable that we use tilde (`~/`) imports relative to `src` directory of each individual app. Currently, both apps have their own babel config. 

When adding a global storybook to our monorepo, the replacing of imports by `babel-plugin-root-import` would break, because it would use the monorepo root as root instead of each individual app for the stories within one of the apps.

The `root` option as a function would be helpful, because we can determine the root from the file name like so:

```
root: sourceFile => {
    if (sourceFile.includes('apps/first-app')) {
      return path.resolve(__dirname, './apps/first-app');
    }

    // etc
  }
```

There was a bug however, where it would split the `root` of the `sourcePath` if the file was absolute. This lead to the file still being resolved relative to the current directory instead of the root specified in `options.root`.

