### PR TITLE
Update eslint plugin repo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ jest.mock('~/myfile')
 If you use [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import)
 to validate imports it may be necessary to instruct ESLint to parse root imports. You
 can use
-[eslint-import-resolver-babel-plugin-root-import](https://github.com/bingqichen/eslint-import-resolver-babel-plugin-root-import)
+[eslint-import-resolver-babel-plugin-root-import](https://github.com/unconfident/eslint-import-resolver-babel-plugin-root-import)
 
 ```json
   "settings": {


### PR DESCRIPTION
bingqichen/eslint-import-resolver-babel-plugin-root-import has been transfered to unconfident/eslint-import-resolver-babel-plugin-root-import

See [issues#14](https://github.com/olalonde/eslint-import-resolver-babel-root-import/issues/14) for details.