### PR TITLE
Dynamic import / require with template literal

### DIFF
--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -31,13 +31,22 @@ describe('Babel Root Import - Plugin', () => {
   });
 
   it('transforms for import() syntax', () => {
-    const targetRequire = slash(`/some/example.js`);
+    const targetRequire = slash(`'./some/example.js'`);
     const transformed = babelTransform(
       "var SomeExample = import('~/some/example.js');",
       {
         plugins: [importSyntaxPlugin, BabelRootImportPlugin],
       },
     );
+
+    expect(transformed.code).to.contain(targetRequire);
+  });
+
+  it('transforms for import() syntax with template literal', () => {
+    const targetRequire = slash('`./some/${foo}`');
+    const transformed = babelTransform('var SomeExample = import(`~/some/${foo}`);', {
+      plugins: [importSyntaxPlugin, BabelRootImportPlugin],
+    });
 
     expect(transformed.code).to.contain(targetRequire);
   });

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -31,9 +31,9 @@ describe('Babel Root Import - Plugin', () => {
   });
 
   it('transforms for import() syntax', () => {
-    const targetRequire = slash(`'./some/example.js'`);
+    const targetRequire = slash(`"./some/example.js"`);
     const transformed = babelTransform(
-      "var SomeExample = import('~/some/example.js');",
+      'var SomeExample = import("~/some/example.js");',
       {
         plugins: [importSyntaxPlugin, BabelRootImportPlugin],
       },
@@ -47,6 +47,18 @@ describe('Babel Root Import - Plugin', () => {
     const transformed = babelTransform('var SomeExample = import(`~/some/${foo}`);', {
       plugins: [importSyntaxPlugin, BabelRootImportPlugin],
     });
+
+    expect(transformed.code).to.contain(targetRequire);
+  });
+
+  it('transforms for require() with template literal', () => {
+    const targetRequire = slash('`./some/${foo}`');
+    const transformed = babelTransform(
+      'var SomeExample = require(`~/some/${foo}`);',
+      {
+        plugins: [BabelRootImportPlugin],
+      },
+    );
 
     expect(transformed.code).to.contain(targetRequire);
   });


### PR DESCRIPTION
Examples that were previously left unmodified.

```js
import(`~/${expr}`) // -> import(`../../${expr}`)
require(`~/${expr}`) // -> require(`../../${expr}`)
```

Resolves #141